### PR TITLE
remove redundant xs:attributeGroup ending tag from xsd

### DIFF
--- a/GW2MarkerPack.xsd
+++ b/GW2MarkerPack.xsd
@@ -897,7 +897,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:attributeGroup>
-  </xs:attributeGroup>
+  
 
   <xs:attributeGroup name="bh-MarkerAndTrailAttr">
     <xs:attribute name="bh-type" type="xs:string">


### PR DESCRIPTION
There is a redundant xs:attributeGroup ending tag, which makes the xsd actually invalid somehow. This pull request removes it.